### PR TITLE
Add nameTemplate to project.json

### DIFF
--- a/generators/app/templates/project.json
+++ b/generators/app/templates/project.json
@@ -1,5 +1,6 @@
 {
   "name": "<%= meta.name %>",
+  "nameTemplate": "<%= meta.name %>",
   "description": "<%= meta.description %>",
   "role": "arn:aws:iam::148400639408:role/axios_apex_default_lambda_function",
   "memory": 128,


### PR DESCRIPTION
Include a `nameTemplate` filed in `project.json`. Without this, the name of the Lambda in AWS is created as `meta.name_meta.name`.

Example: A project called `go_lambda_dev` is created as `go_lambda_dev_go_lambda_dev`.

<img width="499" alt="Screen Shot 2019-08-03 at 3 08 57 PM" src="https://user-images.githubusercontent.com/3457341/62416926-e1704f80-b600-11e9-97ac-2a6cfa587093.png">
